### PR TITLE
Fix: Persist user settings across app updates

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,8 +13,6 @@ files:
 extraResources:
   - from: '.env.example'
     to: '.env.example'
-  - from: '.env.example'
-    to: '.env'
 asarUnpack:
   - resources/**
 win:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,8 +23,8 @@ const getEnvPath = (): string => {
   if (is.dev) {
     return path.resolve(__dirname, '../../.env')
   }
-  // In production, use the app.getAppPath() to get the app.asar directory
-  return path.join(app.getAppPath(), '../.env')
+  // In production, use userData directory so settings persist across app updates
+  return path.join(app.getPath('userData'), '.env')
 }
 
 const getExampleEnvPath = (): string => {
@@ -90,14 +90,30 @@ async function ensureEnvFile(): Promise<void> {
 
   try {
     await fs.access(envPath)
+    return // .env already exists at the target location
   } catch {
-    // If .env doesn't exist, copy from .env.example
+    // .env doesn't exist at the target location
+  }
+
+  // Migration: check if .env exists at the old location (next to app.asar)
+  if (!is.dev) {
+    const oldEnvPath = path.join(app.getAppPath(), '../.env')
     try {
-      const exampleContent = await fs.readFile(exampleEnvPath, 'utf-8')
-      await fs.writeFile(envPath, exampleContent)
-    } catch (error) {
-      console.error('Failed to create .env file:', error)
+      const oldContent = await fs.readFile(oldEnvPath, 'utf-8')
+      await fs.writeFile(envPath, oldContent)
+      console.log('Migrated .env from app directory to userData')
+      return
+    } catch {
+      // Old .env doesn't exist, fall through to create from template
     }
+  }
+
+  // Create from .env.example template
+  try {
+    const exampleContent = await fs.readFile(exampleEnvPath, 'utf-8')
+    await fs.writeFile(envPath, exampleContent)
+  } catch (error) {
+    console.error('Failed to create .env file:', error)
   }
 }
 


### PR DESCRIPTION
## Summary
- Move `.env` storage from app install directory to Electron `userData` directory so user settings (API keys, config) survive app updates
- Add migration logic to copy existing `.env` from old location on first launch after update
- Remove bundled `.env` from `extraResources` in electron-builder (only `.env.example` template is bundled now)

## Test plan
- [x] Dev mode: `npm run dev` loads `.env` from project root (unchanged)
- [x] Production build: `npm run build` + typecheck passes
- [ ] Production install: verify `.env` is created in `~/Library/Application Support/Kobo2Notion/` (or platform equivalent)
- [ ] Migration: existing users' settings are preserved on first update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes where configuration is read/written in production and adds first-run migration logic that could affect startup if path or file permissions differ across platforms.
> 
> **Overview**
> **Persists user configuration across updates** by changing production `.env` resolution from the app install directory to Electron `app.getPath('userData')`.
> 
> Adds migration in `ensureEnvFile()` to copy an existing `.env` from the old location (next to `app.asar`) into `userData` on first run, otherwise creating a new `.env` from the bundled `.env.example`.
> 
> Updates packaging (`electron-builder.yml`) to stop shipping a `.env` file and only include `.env.example` as a template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec62631990fab428b06e03507a3f9b94022ea694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->