### PR TITLE
Fix: Persist settings across updates (v1.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kobo2notion",
   "productName": "Kobo2Notion",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Easily sync your Kobo highlights to Notion.",
   "main": "./out/main/index.js",
   "author": "ghnmqdtg@gmail.com",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,8 +89,11 @@ async function ensureEnvFile(): Promise<void> {
   const exampleEnvPath = getExampleEnvPath()
 
   try {
-    await fs.access(envPath)
-    return // .env already exists at the target location
+    const stat = await fs.stat(envPath)
+    if (stat.size > 0) {
+      return // .env already exists with content at the target location
+    }
+    // .env exists but is empty, treat as missing
   } catch {
     // .env doesn't exist at the target location
   }
@@ -100,9 +103,11 @@ async function ensureEnvFile(): Promise<void> {
     const oldEnvPath = path.join(app.getAppPath(), '../.env')
     try {
       const oldContent = await fs.readFile(oldEnvPath, 'utf-8')
-      await fs.writeFile(envPath, oldContent)
-      console.log('Migrated .env from app directory to userData')
-      return
+      if (oldContent.trim().length > 0) {
+        await fs.writeFile(envPath, oldContent)
+        console.log('Migrated .env from app directory to userData')
+        return
+      }
     } catch {
       // Old .env doesn't exist, fall through to create from template
     }


### PR DESCRIPTION
## Summary
- Fix empty `.env` in userData causing migration to be skipped
- Check file size before assuming `.env` is valid
- Check old `.env` has content before migrating

## Context
v1.1.2 had a bug: an empty `.env` (0 bytes) already existed in `userData` from a prior run, so `fs.access` succeeded and migration was skipped entirely.